### PR TITLE
Use fully qualified path to delete old directories

### DIFF
--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -167,7 +167,7 @@ function clean_out_old_releases(){
     while [ $(ls -tr "${RELEASES_DIR}" | wc -l) -gt 2 ] ; do
         OLDEST_RELEASE=$(ls -tr "${RELEASES_DIR}" | head -1)
         log "Deleting old release '${OLDEST_RELEASE}'"
-        rm -rf "$OLDEST_RELEASE"
+        rm -rf "${RELEASES_DIR}/${OLDEST_RELEASE}"
     done
 }
 


### PR DESCRIPTION
@liamneesonsarm @gerbercj 

tested this from inside the releases directory, where it would have worked. Smacks forehead.
