### PR TITLE
Escape backticks and $ in saved environment so they are preseved from one save to the next

### DIFF
--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -69,7 +69,11 @@ function save_environment(){
     # filter out multiline junk and _. _ is a readonly variable 
     env | egrep "^[^ ]+=.*" | grep -v "^_=" | while read ENVVAR ; do
         local NAME=${ENVVAR%%=*}
-        local VALUE=$(eval echo '$'$NAME)
+        # sed is to preserve variable values with dollars (for escaped variables or $() style command replacement),
+        # and command replacement backticks
+        # Escaped parens captures backward reference \1 which gets replaced with backslash and \1 to esape them in the saved
+        # variable value
+        local VALUE=$(eval echo '$'$NAME | sed 's/\([$`]\)/\\\1/g')
         echo "export $NAME=\"$VALUE\"" >> ${METADATA}
     done
     


### PR DESCRIPTION
This is to preserve command replacement in things like the logrotate command for chore. The value is 

``` sh
su - webuser -c 'kill -s USR1 \`/opt/apps/tapjoyserver/server/chore_master_pid.rb\`'
```

If we source that and then save it again the backticks get unescaped and then excuted on save. The sed command here keeps them escaped so the value is the same if we source the environment we saved and source and save and source and save etc.

@liamneesonsarm @gerbercj @andyleclair  
