### PR TITLE
Move pids up to install root to prevent "folder *not* empty" problem

### DIFF
--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -50,19 +50,19 @@ function main() {
 
 # deletes the PID file for this installation
 function delete_pid(){
-    rm -f ${INSTALL_DIR}/$$.pid 2> /dev/null
+    rm -f ${INSTALL_ROOT}/$$.pid 2> /dev/null
 }
 
 # creates a PID file for this installation
 function create_pid(){
     trap "delete_pid" EXIT
-    echo $$> ${INSTALL_DIR}/$$.pid
+    echo $$> ${INSTALL_ROOT}/$$.pid
 }
 
 
 # checks for other PID files and sleeps for a grace period if found
 function wait_for_others(){
-    local count=`ls ${INSTALL_DIR}/*.pid | wc -l`
+    local count=`ls ${INSTALL_ROOT}/*.pid | wc -l`
 
     if [ $count -gt 1 ] ; then
         sleep 10
@@ -71,7 +71,7 @@ function wait_for_others(){
 
 # kills other running installations
 function kill_others(){
-    for PID_FILE in $(ls ${INSTALL_DIR}/*.pid) ; do
+    for PID_FILE in $(ls ${INSTALL_ROOT}/*.pid) ; do
         local p=`cat ${PID_FILE}`
         if ! [ $p == $$ ] ; then
             kill -9 $p


### PR DESCRIPTION
SO... the problem that we had with empty deploys directory has to do with how I was tracking running slug installations. I was storing a PID file in the folder so that I could then use those PID files to find the other running installs. The problem was that I created them in the INSTALL_DIRs. This meant that when we went to check if the folder was empty, it _absolutely_ was not. :frowning:

This change moves those PID files up to the INSTALL_ROOT, which gets rid of that problem. I manually hacked this into a FPM 1.1.0 created slug and the install started working.

@Tapjoy/opsautomation
