### PR TITLE
Fix post_install to capture output and errorlevel correctly

### DIFF
--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -163,8 +163,10 @@ function run_post_install(){
     if [ -r $AFTER_INSTALL ] ; then
         chmod +x $AFTER_INSTALL
         log "Running post install script"
-        log $($AFTER_INSTALL)
-        return $?
+        output=$($AFTER_INSTALL 2>&1)
+        errorlevel=$?
+        log $output
+        return $errorlevel
     fi
     return 0
 }


### PR DESCRIPTION
This is the logging bug that was preventing rollbacks from occurring.

@ofanite, @ehealy, @marcuswalser, @jjrussell
cc: @Tapjoy/opsautomation
