### PR TITLE
Temporary work-around for analytics logger issue

### DIFF
--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -200,7 +200,7 @@ function revert_symlinks(){
 function clean_out_old_releases(){
     [ -n "$USE_FLAT_RELEASE_DIRECTORY" ] && return
 
-    while [ $(ls -tr "${RELEASES_DIR}" | wc -l) -gt 2 ] ; do
+    while [ $(ls -tr "${RELEASES_DIR}" | wc -l) -gt 4 ] ; do
         OLDEST_RELEASE=$(ls -tr "${RELEASES_DIR}" | head -1)
         log "Deleting old release '${OLDEST_RELEASE}'"
         rm -rf "${RELEASES_DIR}/${OLDEST_RELEASE}"


### PR DESCRIPTION
As per our discussion, this is a temporary workaround to buy us time. The real fix is to ensure that the previous current folder is not deleted at the end of a deploy, despite the age of the directory.
@jjrussell, @obrie
cc @Tapjoy/opsautomation
