### PR TITLE
Detect reinstall of current slug, and exit unless forced

### DIFF
--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,3 +1,3 @@
 module FPM
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -21,31 +21,50 @@ set -e
 function main() {
     set_install_dir
 
-    create_pid
+    if ! slug_already_current ; then
 
-    wait_for_others
+      create_pid
+      wait_for_others
+      kill_others
+      set_owner
+      unpack_payload
 
-    kill_others
+      if [ "$UNPACK_ONLY" == "1" ] ; then
+          echo "Unpacking complete, not moving symlinks or restarting because unpack only was specified."
+      else
+          create_symlinks
 
-    set_owner
+          set +e # don't exit on errors to allow us to clean up
+          if ! run_post_install ; then
+              revert_symlinks
+              log "Installation failed."
+              exit 1
+          else
+              clean_out_old_releases
+              log "Installation complete."
+          fi
+      fi
 
-    unpack_payload
-
-    if [ "$UNPACK_ONLY" == "1" ] ; then
-        echo "Unpacking complete, not moving symlinks or restarting because unpack only was specified."
     else
-        create_symlinks
-
-        set +e # don't exit on errors to allow us to clean up
-        if ! run_post_install ; then
-            revert_symlinks
-            log "Installation failed."
-            exit 1
-        else
-            clean_out_old_releases
-            log "Installation complete."
-        fi
+        echo "This slug is already installed in 'current'. Specify -f to force reinstall. Exiting."
     fi
+}
+
+# check if this slug is already running and exit unless `force` specified
+function slug_already_current(){
+    if [ "$FORCE" == "1" ] ; then
+        log "Force was specified. Proceeding with install."
+        return 1;
+    fi
+
+    local this_slug=$(basename $0 .slug)
+    local current=$(basename $(readlink ${INSTALL_ROOT}/current))
+    log "'current' symlink points to slug: ${current}"
+
+    if [ "$this_slug" == "$current" ] ; then
+        return 0;
+    fi
+    return 1;
 }
 
 # deletes the PID file for this installation


### PR DESCRIPTION
This change should detect if the slug being installed is already the 'current' slug on the host, and will skip the deploy (unless 'force' was specified).

Test results:

``` sh
$ slugforge deploy tag noop_test g-tapinabox.tapjoy.net --project tapjoyserver --verbose
      deploy  deploying slug tapjoyserver/tapjoyserver-20140804150120-9b4a9d90e6.slug
...
Installing package to '/opt/apps/tapjoyserver/releases/tapjoyserver-20140804150120-9b4a9d90e6'
'current' symlink points to slug: tapjoyserver-20140804144255-9b4a9d90e6
Installing as user webuser
Unpacking payload . . .
Symlinked '/opt/apps/tapjoyserver/releases/tapjoyserver-20140804150120-9b4a9d90e6' to '/opt/apps/tapjoyserver/current'
Running post install script
...
Installation complete.
SSH_COMMAND_EXIT_CODE=0
...
Deployed tapjoyserver-20140804150120-9b4a9d90e6.slug to 1 of 1 hosts in 29 seconds
```

``` sh
$ slugforge deploy tag noop_test g-tapinabox.tapjoy.net --project tapjoyserver --verbose
      deploy  deploying slug tapjoyserver/tapjoyserver-20140804150120-9b4a9d90e6.slug
...
Installing package to '/opt/apps/tapjoyserver/releases/tapjoyserver-20140804150120-9b4a9d90e6'
'current' symlink points to slug: tapjoyserver-20140804150120-9b4a9d90e6
This slug is already installed in 'current'. Specify -f to force reinstall. Exiting.
SSH_COMMAND_EXIT_CODE=0
...
Deployed tapjoyserver-20140804150120-9b4a9d90e6.slug to 1 of 1 hosts in 2 seconds
```

@Tapjoy/opsautomation 
