### PR TITLE
Ignore ENV exported functions

### DIFF
--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -127,8 +127,8 @@ function save_environment(){
     echo -n "" > ${METADATA} # empty file
 
     # just piping env to a file doesn't quote the variables. This does
-    # filter out multiline junk and _. _ is a readonly variable
-    env | egrep "^[^ ]+=.*" | grep -v "^_=" | while read ENVVAR ; do
+    # filter out multiline junk, _, and functions. _ is a readonly variable.
+    env | grep -v "^_=" | grep -v "^[^=(]*()=" | egrep "^[^ ]+=" | while read ENVVAR ; do
         local NAME=${ENVVAR%%=*}
         # sed is to preserve variable values with dollars (for escaped variables or $() style command replacement),
         # and command replacement backticks


### PR DESCRIPTION
We recently saw an issue where RVM versions 1.25.29-31 were exporting a function into the environment using `export -f`. When Bash 4.3.27 was released, it changed how this export was happening. This change broke the environment parsing that we did in FPM for loading/saving our .install-metadata file. This change will cause those exported functions to be ignored.

@Tapjoy/opsautomation @jjrussell 
