### PR TITLE
changing versioning semantic 1.3.3.tj1 to 1.3.4 + add support for slug metadata as env vars

### DIFF
--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,3 +1,3 @@
 module FPM
-  VERSION = "1.3.3.tj1"
+  VERSION = "1.3.4"
 end

--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -187,6 +187,7 @@ function unpack_payload(){
 function run_post_install(){
     local AFTER_INSTALL=$INSTALL_DIR/.fpm/after_install
     if [ -r $AFTER_INSTALL ] ; then
+        set_post_install_vars
         chmod +x $AFTER_INSTALL
         log "Running post install script"
         output=$($AFTER_INSTALL 2>&1)
@@ -195,6 +196,15 @@ function run_post_install(){
         return $errorlevel
     fi
     return 0
+}
+
+function set_post_install_vars(){
+    <% if respond_to?(:package_metadata)%>
+      <% package_metadata_hash = JSON.parse(package_metadata)%>
+      <% package_metadata_hash.each do |k,v| %>
+        <%= "export #{k.upcase}='#{v}'; "%>
+      <% end %>
+    <% end %>
 }
 
 function create_symlinks(){


### PR DESCRIPTION
@Tapjoy/opsautomation @gerbercj was having strange problems in development when using the current version fpm that contains a beta naming semantic (1.3.3tj1):

ehealy:~/projects/toad [feature/slugforge_asset_build_testing *]$ fpm --version
Missing required -s flag. What package source did you want? {:level=>:warn}
Missing required -t flag. What package output did you want? {:level=>:warn}
No parameters given. You need to pass additional command arguments so that I know what you want to build packages from. For example, for '-s dir' you would pass a list of files and directories. For '-s gem' you would pass a one or more gems to package from. As a full example, this will make an rpm of the 'json' rubygem: `fpm -s gem -t rpm json` {:level=>:warn}
Fix the above problems, and you'll be rolling packages in no time! {:level=>:fatal}

and caused issues with fpm usage within slugforge. 

Bumping the version to 1.3.4 resolved the issues.

