### PR TITLE
Feature/fix symlink removal for mac

### DIFF
--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,3 +1,3 @@
 module FPM
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
 end

--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -61,7 +61,7 @@ function slug_already_current(){
         if [ "$FORCE" == "1" ] ; then
         log "Force was specified. Proceeding with install after renaming live directory to allow running service to shutdown correctly."
             local real_dir=$(readlink ${INSTALL_ROOT}/current)
-            if [ -f ${real_dir}.old ] ; then
+            if [ -f ${real_dir}.old ]; then
                 # remove that .old directory, if needed
                 rm -rf ${real_dir}.old
             fi
@@ -211,7 +211,8 @@ function create_symlinks(){
     [ -n "$USE_FLAT_RELEASE_DIRECTORY" ] && return
 
     export CURRENT_DIR="$INSTALL_ROOT/current"
-    if [ -e "$CURRENT_DIR" ] ; then
+    if [ -L "$CURRENT_DIR" ] ; then
+        log "Removing current symlink"
         OLD_CURRENT_TARGET=$(readlink $CURRENT_DIR)
         rm "$CURRENT_DIR"
     fi

--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -61,7 +61,7 @@ function slug_already_current(){
         if [ "$FORCE" == "1" ] ; then
         log "Force was specified. Proceeding with install after renaming live directory to allow running service to shutdown correctly."
             local real_dir=$(readlink ${INSTALL_ROOT}/current)
-            if [ -f ${real_dir}.old ]; then
+            if [ -f ${real_dir}.old ] ; then
                 # remove that .old directory, if needed
                 rm -rf ${real_dir}.old
             fi
@@ -211,7 +211,9 @@ function create_symlinks(){
     [ -n "$USE_FLAT_RELEASE_DIRECTORY" ] && return
 
     export CURRENT_DIR="$INSTALL_ROOT/current"
-    if [ -L "$CURRENT_DIR" ] ; then
+    # -e checks if a file or folder exists
+    # -h covers the case where we may have a broken symlink in place
+    if [ -e "$CURRENT_DIR" ] || [ -h "$CURRENT_DIR" ]; then
         log "Removing current symlink"
         OLD_CURRENT_TARGET=$(readlink $CURRENT_DIR)
         rm "$CURRENT_DIR"


### PR DESCRIPTION
@Tapjoy/eng-group-ops @gerbercj found this when testing. `[ -e <a symlink> ]` returns false in a mac environment, and true in a Linux environment. This will allow us to force local installs for deployboard in the event it's running locally on a mac. Not entirely needed immediately but probably something we should address. 