### PR TITLE
OPER-5088 Pin `backports` gem to fix new breakage

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |spec|
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
   spec.add_dependency("json", ">= 1.7.7") # license: Ruby License
-  
+
   # For logging
   # https://github.com/jordansissel/ruby-cabin
-  spec.add_dependency("cabin", ">= 0.6.0") # license: Apache 2 
+  spec.add_dependency("cabin", ">= 0.6.0") # license: Apache 2
 
   # For backports to older rubies
   # https://github.com/marcandre/backports
-  spec.add_dependency("backports", ">= 2.6.2") # license: MIT
+  spec.add_dependency("backports", "2.6.7") # license: MIT
 
   # For reading and writing rpms
   spec.add_dependency("arr-pm", "~> 0.0.9") # license: Apache 2
@@ -57,4 +57,3 @@ Gem::Specification.new do |spec|
   spec.email = "jls@semicomplete.com"
   spec.homepage = "https://github.com/jordansissel/fpm"
 end
-

--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,4 +1,4 @@
 module FPM
   # Use the 4th number for TJ specific version
-  VERSION = "1.3.5.1"
+  VERSION = "1.3.5.2"
 end


### PR DESCRIPTION
Slug builds are failing for new and utterly uninteresting reasons. This should fix it. Shoot me in the face.

All package managers that proactively update external dependencies should die in a trashfire.

I'm sure it has something to do with us using RUBY_VERSION in the slug build script. At any rate, I don't care. Other people are running into this too ... TLDR we are pinning to a version that works for us.

Once this is approved I will publish to Gemfury and update the `slug-builder` script.